### PR TITLE
Service Account implementation and Api Key by Logical Clusters

### DIFF
--- a/ccloud/provider.go
+++ b/ccloud/provider.go
@@ -26,9 +26,10 @@ func Provider() terraform.ResourceProvider {
 		},
 		ConfigureFunc: providerConfigure,
 		ResourcesMap: map[string]*schema.Resource{
-			"confluentcloud_kafka_cluster": kafkaClusterResource(),
-			"confluentcloud_api_key":       apiKeyResource(),
-			"confluentcloud_environment":   environmentResource(),
+			"confluentcloud_kafka_cluster":   kafkaClusterResource(),
+			"confluentcloud_api_key":         apiKeyResource(),
+			"confluentcloud_environment":     environmentResource(),
+			"confluentcloud_service_account": serviceAccountResource(),
 		},
 	}
 }

--- a/ccloud/resource_service_account.go
+++ b/ccloud/resource_service_account.go
@@ -1,0 +1,91 @@
+package ccloud
+
+import (
+	"fmt"
+	"log"
+	"strconv"
+
+	ccloud "github.com/cgroschupp/go-client-confluent-cloud/confluentcloud"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func serviceAccountResource() *schema.Resource {
+	return &schema.Resource{
+		Create: serviceAccountCreate,
+		Read:   serviceAccountRead,
+		Delete: serviceAccountDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "",
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Service Account Description",
+			},
+		},
+	}
+}
+
+func serviceAccountCreate(d *schema.ResourceData, meta interface{}) error {
+	c := meta.(*ccloud.Client)
+
+	name := d.Get("name").(string)
+	description := d.Get("description").(string)
+
+	req := ccloud.ServiceAccountCreateRequest{
+		Name:        name,
+		Description: description,
+	}
+
+	serviceAccount, err := c.CreateServiceAccount(&req)
+	if err == nil {
+		d.SetId(fmt.Sprintf("%d", serviceAccount.ID))
+
+		err = d.Set("name", serviceAccount.Name)
+		if err != nil {
+			return err
+		}
+
+		err = d.Set("description", serviceAccount.Description)
+		if err != nil {
+			return err
+		}
+	} else {
+		log.Printf("[ERROR] Could not create Service Account: %s", err)
+	}
+
+	return nil
+}
+
+func serviceAccountRead(d *schema.ResourceData, meta interface{}) error {
+	return nil
+}
+
+func serviceAccountDelete(d *schema.ResourceData, meta interface{}) error {
+	c := meta.(*ccloud.Client)
+
+	ID, err := strconv.Atoi(d.Id())
+	if err != nil {
+		log.Println("[ERROR] Could not parse Service Account ID %s to int", d.Id())
+		return err
+	}
+
+	err = c.DeleteServiceAccount(ID)
+
+	if err != nil {
+		log.Printf("[ERROR] Service Account can not be deleted: %s", ID)
+		return err
+	}
+
+	log.Printf("[INFO] Service Account deleted: %s", ID)
+
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,8 @@ module github.com/Mongey/terraform-provider-confluent-cloud
 go 1.12
 
 require (
-	github.com/cgroschupp/go-client-confluent-cloud v0.0.0-20200422075006-8017b3106b01
+	github.com/cgroschupp/go-client-confluent-cloud v0.0.0-20200525125748-b0492510d3f8
+	github.com/go-resty/resty/v2 v2.2.0 // indirect
 	github.com/hashicorp/terraform v0.12.1
+	golang.org/x/net v0.0.0-20200520004742-59133d7f0dd7 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -56,6 +56,8 @@ github.com/cgroschupp/go-client-confluent-cloud v0.0.0-20200122085348-d9bc153ee7
 github.com/cgroschupp/go-client-confluent-cloud v0.0.0-20200122085348-d9bc153ee7b7/go.mod h1:4qz2Pftxeus+mcGJkiysWrDwf/uQL1+jEI/Yu5BpS60=
 github.com/cgroschupp/go-client-confluent-cloud v0.0.0-20200422075006-8017b3106b01 h1:K11k3izMB/Zi02o714ySv5bzqf/WUxLi+adfHij078w=
 github.com/cgroschupp/go-client-confluent-cloud v0.0.0-20200422075006-8017b3106b01/go.mod h1:4qz2Pftxeus+mcGJkiysWrDwf/uQL1+jEI/Yu5BpS60=
+github.com/cgroschupp/go-client-confluent-cloud v0.0.0-20200525125748-b0492510d3f8 h1:T/T2UyF4/cJWSzb/wIKpTaUONFdJIEaZT+4CWIi7GEg=
+github.com/cgroschupp/go-client-confluent-cloud v0.0.0-20200525125748-b0492510d3f8/go.mod h1:4qz2Pftxeus+mcGJkiysWrDwf/uQL1+jEI/Yu5BpS60=
 github.com/cheggaaa/pb v1.0.27/go.mod h1:pQciLPpbU0oxA0h+VJYYLxO+XeDQb5pZijXscXHm81s=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20161106042343-c914be64f07d/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
@@ -83,6 +85,8 @@ github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeME
 github.com/gliderlabs/ssh v0.1.1/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aevW3Awn0=
 github.com/go-resty/resty/v2 v2.1.0 h1:Z6IefCpUMfnvItVJaJXWv/pMiiD11So35QgwEELsldE=
 github.com/go-resty/resty/v2 v2.1.0/go.mod h1:dZGr0i9PLlaaTD4H/hoZIDjQ+r6xq8mgbRzHZf7f2J8=
+github.com/go-resty/resty/v2 v2.2.0 h1:vgZ1cdblp8Aw4jZj3ZsKh6yKAlMg3CHMrqFSFFd+jgY=
+github.com/go-resty/resty/v2 v2.2.0/go.mod h1:nYW/8rxqQCmI3bPz9Fsmjbr2FBjGuR2Mzt6kDh3zZ7w=
 github.com/go-test/deep v1.0.1 h1:UQhStjbkDClarlmv0am7OXXO4/GaPdCGiUiMTvi28sg=
 github.com/go-test/deep v1.0.1/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
@@ -340,6 +344,9 @@ golang.org/x/net v0.0.0-20190502183928-7f726cade0ab h1:9RfW3ktsOZxgo9YNbBAjq1FWz
 golang.org/x/net v0.0.0-20190502183928-7f726cade0ab/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190628185345-da137c7871d7 h1:rTIdg5QFRR7XCaK4LCjBiPbx8j4DQRpdYMnGn/bJUEU=
 golang.org/x/net v0.0.0-20190628185345-da137c7871d7/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20200222125558-5a598a2470a0/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20200520004742-59133d7f0dd7 h1:AeiKBIuRw3UomYXSbLy0Mc2dDLfdtbT/IVn4keq83P0=
+golang.org/x/net v0.0.0-20200520004742-59133d7f0dd7/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20181017192945-9dcd33a902f4/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20181203162652-d668ce993890/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -363,6 +370,7 @@ golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190502175342-a43fa875dd82 h1:vsphBvatvfbhlb4PO1BYSr9dzugGxJ/SQHoNufZJq1w=
 golang.org/x/sys v0.0.0-20190502175342-a43fa875dd82/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=


### PR DESCRIPTION
Hi,

I need to change the provider to achieve those items in my project:

* Confluent Cloud **Service Account** managing capability resource (like #8).
* Possibility to configure the list of logical cluster when creating API KEY: to not break compatibility, I leave the parameter *cluster_id* and created a new one *logical_clusters*. We can use both ways and I check if there same value is informed to send one time to final resource.

I'm not a GO developer, sorry if I did anything wrong. ;-)

closes #8 