### PR TITLE
Support importing existing Kafka clusters (fixes #64)

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ output "secret" {
 
 This provider supports importing existing Confluent Cloud resources via [`terraform import`][3].
 
-Most resource types use the import IDs returned by the [`ccloud`][4] CLI, with the exception of clusters, which expect an import ID of the form `<environment ID>:<cluster ID>`.
+Most resource types use the import IDs returned by the [`ccloud`][4] CLI, with the exception of clusters, which expect an import ID of the form `<environment ID>/<cluster ID>`.
 
 [1]: https://www.terraform.io
 [2]: https://confluent.cloud

--- a/README.md
+++ b/README.md
@@ -114,6 +114,14 @@ output "secret" {
 }
 ```
 
+## Importing existing resources
+
+This provider supports importing existing Confluent Cloud resources via [`terraform import`][3].
+
+Most resource types use the import IDs returned by the [`ccloud`][4] CLI, with the exception of clusters, which expect an import ID of the form `<environment ID>:<cluster ID>`.
+
 [1]: https://www.terraform.io
 [2]: https://confluent.cloud
+[3]: https://www.terraform.io/docs/cli/import/index.html
+[4]: https://docs.confluent.io/ccloud-cli/current/index.html
 [third-party-plugins]: https://www.terraform.io/docs/configuration/providers.html#third-party-plugins

--- a/ccloud/resource_kafka_cluster.go
+++ b/ccloud/resource_kafka_cluster.go
@@ -244,8 +244,8 @@ func clusterDelete(ctx context.Context, d *schema.ResourceData, meta interface{}
 }
 
 func clusterImport(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData, error) {
-	envIDAndClusterId := d.Id()
-	parts := strings.Split(envIDAndClusterId, ":")
+	envIDAndClusterID := d.Id()
+	parts := strings.Split(envIDAndClusterID, "/")
 
 	var err error
 	if len(parts) != 2 {

--- a/ccloud/resource_kafka_cluster.go
+++ b/ccloud/resource_kafka_cluster.go
@@ -20,7 +20,7 @@ func kafkaClusterResource() *schema.Resource {
 		ReadContext:   clusterRead,
 		DeleteContext: clusterDelete,
 		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
+			StateContext: clusterImport,
 		},
 		Schema: map[string]*schema.Schema{
 			"name": {
@@ -241,6 +241,24 @@ func clusterDelete(ctx context.Context, d *schema.ResourceData, meta interface{}
 		return diag.FromErr(err)
 	}
 	return diags
+}
+
+func clusterImport(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData, error) {
+	envIDAndClusterId := d.Id()
+	parts := strings.Split(envIDAndClusterId, ":")
+
+	var err error
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid format for cluster import: expected '<env ID>:<cluster ID>'")
+	}
+
+	d.SetId(parts[1])
+	err = d.Set("environment_id", parts[0])
+	if err != nil {
+		return nil, err
+	}
+
+	return []*schema.ResourceData{d}, nil
 }
 
 func clusterRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/ccloud/resource_kafka_cluster_test.go
+++ b/ccloud/resource_kafka_cluster_test.go
@@ -2,6 +2,7 @@ package ccloud
 
 import (
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"os"
 	"testing"
 
@@ -37,6 +38,17 @@ func TestAcc_BasicCluster(t *testing.T) {
 		Steps: []r.TestStep{
 			{
 				Config: fmt.Sprintf(testResourceCluster_noConfig, u, u),
+			},
+			{
+				ResourceName: "confluentcloud_kafka_cluster.test",
+				ImportState: true,
+				ImportStateIdFunc: func(state *terraform.State) (string, error) {
+					resources := state.RootModule().Resources
+					clusterId := resources["confluentcloud_kafka_cluster.test"].Primary.ID
+					envId := resources["confluentcloud_environment.test"].Primary.ID
+					return envId + ":" + clusterId, nil
+				},
+				ImportStateVerify: true,
 			},
 		},
 	})

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/go-resty/resty/v2 v2.2.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.0 // indirect
-	github.com/hashicorp/go-uuid v1.0.2 // indirect
+	github.com/hashicorp/go-uuid v1.0.2
 	github.com/hashicorp/terraform-plugin-docs v0.3.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.4.4
 	github.com/hashicorp/yamux v0.0.0-20200609203250-aecfd211c9ce // indirect


### PR DESCRIPTION
This change should address the issue reported in #64 wherein it's not currently possible to import existing Kafka clusters.

The issue is that the read function for clusters requires both the cluster ID and the containing environment ID, which means that using the pass-through state importer function doesn't work.

I've addressed this by allowing clusters to be imported by passing an import ID of the form `<environment ID>/<cluster ID>`.