### PR TITLE
Allow creating API keys for non-clusters

### DIFF
--- a/examples/main.tf
+++ b/examples/main.tf
@@ -38,8 +38,17 @@ resource "confluentcloud_schema_registry" "test" {
   depends_on = [confluentcloud_kafka_cluster.test]
 }
 
+# api key for a kafka cluster
 resource "confluentcloud_api_key" "provider_test" {
   cluster_id     = confluentcloud_kafka_cluster.test.id
+  environment_id = confluentcloud_environment.environment.id
+}
+
+# api key for schema registry
+resource "confluentcloud_api_key" "schema-registry" {
+  logical_clusters = [
+    confluentcloud_schema_registry.test.id
+  ]
   environment_id = confluentcloud_environment.environment.id
 }
 


### PR DESCRIPTION
I am willing to re-work this some if it is too hacky. But this change allowed me to create api keys for schema registries. They were failing since this provider was attempting to wait for the kafka cluster and was getting a "null reference exception".