### PR TITLE
feat: Add config_sensitive parameter for sensitive connector config

### DIFF
--- a/ccloud/resource_connector.go
+++ b/ccloud/resource_connector.go
@@ -60,7 +60,7 @@ func connectorResource() *schema.Resource {
 				Type:        schema.TypeMap,
 				Required:    true,
 				ForceNew:    false,
-				Description: "Type-specific Configuration of cluster. String keys and values",
+				Description: "Type-specific Configuration of connector. String keys and values",
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 					// ignore common auto-generated config fields
 					for _, ik := range ignoreConnectorConfigs() {
@@ -82,6 +82,13 @@ func connectorResource() *schema.Resource {
 					return false
 				},
 			},
+			"config_sensitive": {
+				Type:        schema.TypeMap,
+				Optional:    true,
+				ForceNew:    false,
+				Sensitive:   true,
+				Description: "Sensitive part of connector configuration. String keys and values",
+			},
 		},
 	}
 }
@@ -91,12 +98,16 @@ func connectorUpdate(_ context.Context, d *schema.ResourceData, meta interface{}
 
 	name := d.Get("name").(string)
 	config := d.Get("config").(map[string]interface{})
+	configSensitive := d.Get("config_sensitive").(map[string]interface{})
 	accountID := d.Get("environment_id").(string)
 	clusterID := d.Get("cluster_id").(string)
 
 	log.Printf("[DEBUG] Updating connector config")
 	configStrings := make(map[string]string)
 	for key, value := range config {
+		configStrings[key] = value.(string)
+	}
+	for key, value := range configSensitive {
 		configStrings[key] = value.(string)
 	}
 
@@ -117,12 +128,16 @@ func connectorCreate(ctx context.Context, d *schema.ResourceData, meta interface
 
 	name := d.Get("name").(string)
 	config := d.Get("config").(map[string]interface{})
+	configSensitive := d.Get("config_sensitive").(map[string]interface{})
 	accountID := d.Get("environment_id").(string)
 	clusterID := d.Get("cluster_id").(string)
 
 	log.Printf("[DEBUG] Creating connector")
 	configStrings := make(map[string]string)
 	for key, value := range config {
+		configStrings[key] = value.(string)
+	}
+	for key, value := range configSensitive {
 		configStrings[key] = value.(string)
 	}
 

--- a/docs/resources/connector.md
+++ b/docs/resources/connector.md
@@ -16,12 +16,13 @@ description: |-
 ### Required
 
 - **cluster_id** (String) ID of containing cluster, e.g. lkc-abc123
-- **config** (Map of String) Type-specific Configuration of cluster. String keys and values
+- **config** (Map of String) Type-specific Configuration of connector. String keys and values
 - **environment_id** (String) ID of containing environment, e.g. env-abc123
 - **name** (String) The name of the connector
 
 ### Optional
 
+- **config_sensitive** (Map of String) Sensitive part of connector configuration. String keys and values
 - **id** (String) The ID of this resource.
 - **timeouts** (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 

--- a/examples/connector/main.tf
+++ b/examples/connector/main.tf
@@ -1,0 +1,36 @@
+terraform {
+  required_providers {
+    kafka = {
+      source  = "Mongey/kafka"
+      version = "0.2.11"
+    }
+    confluentcloud = {
+      source = "Mongey/confluentcloud"
+    }
+  }
+}
+
+provider "confluentcloud" {}
+
+resource "confluentcloud_connector" "connector" {
+  name             = "pubsub-kafka-connector"
+  environment_id   = "env-ab123"
+  cluster_id       = "lkc-cd456"
+  config           = {
+    "name"                         = "pubsub-kafka-connector"
+    "connector.class"              = "PubSubSource"
+    "kafka.topic"                  = "kafka-topic1"
+    "gcp.pubsub.project.id"        = "project-1234"
+    "gcp.pubsub.subscription.id"   = "topic1-subscription1"
+    "gcp.pubsub.topic.id"          = "topic1"
+    "gcp.pubsub.max.retry.time"    = "5"
+    "gcp.pubsub.message.max.count" = "1000"
+    "errors.tolerance"             = "all"
+    "tasks.max"                    = "1"
+  }
+  config_sensitive = {
+    "kafka.api.key"               = <<kafka-api-key>>
+    "kafka.api.secret"            = <<kafka-api-secret>>
+    "gcp.pubsub.credentials.json" = <<gcp-service-account-key>
+  }
+}


### PR DESCRIPTION
Previously terraform showed all config map, including sensitive parameters like `kafka.api.secret`.

Now such sensitive values could be placed in separate map `config_sensitive`, and terraform will hide them in console output.
Before querying Confluent API both `config` and `config_sensitive` maps union together.