### PR TITLE
fix: Prevent terraform to show continuously changes for connector resource

### DIFF
--- a/ccloud/resource_connector.go
+++ b/ccloud/resource_connector.go
@@ -22,6 +22,7 @@ func ignoreConnectorConfigs() []string {
 		"config.cloud.provider",
 		"config.cloud.environment",
 		"config.valid.kafka.api.key",
+		"config.schema.registry.url",
 	}
 }
 
@@ -73,9 +74,9 @@ func connectorResource() *schema.Resource {
 						return true
 					}
 
-					// Kafka API key and secret pose a problem. What if they REALLY have changed? No way to detect here.
+					// Sensitive data are not returned from status query, so changes made to it outside of terraform could not be tracked
 					masked, _ := regexp.MatchString("\\*+", old)
-					if (k == "config.kafka.api.key" || k == "config.kafka.api.secret") && masked {
+					if masked {
 						return true
 					}
 


### PR DESCRIPTION
All sensitive parameters which are returned as  masked `"****************"` could not be checked if they needed to update. No necessary to hardcode some of them.
Also `"config.schema.registry.url"`is internal returned parameter and should be ignored for update.