### PR TITLE
Add creation timeout parameter for resource cluster

### DIFF
--- a/ccloud/resource_kafka_cluster.go
+++ b/ccloud/resource_kafka_cluster.go
@@ -22,6 +22,9 @@ func kafkaClusterResource() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: clusterImport,
 		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(24 * 60 * time.Minute),
+		},
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:        schema.TypeString,


### PR DESCRIPTION
As per [Confluent documentation](https://docs.confluent.io/cloud/current/clusters/cluster-types.html#provisioning-time), provisioning of dedicated clusters can take up to 24 hours. However, provisioning of clusters failed at due to context deadline being exceeded after 20 minutes ([as per tf documentation, it's a default](https://www.terraform.io/plugin/sdkv2/resources/retries-and-customizable-timeouts)). [This PR](https://github.com/Mongey/terraform-provider-confluentcloud/pull/123) by @borisnaydis tried to address the issue, but changes did not remediate it. This PR adds a configurable timeout parameter for creation of clusters, which defaults to 24 hours, but can be changed in the resource configuration (snippet below). Code is tested locally and with this change it is possible to provision larger clusters to confluent without facing a timeout at around 20 minutes. 

```
resource "confluentcloud_kafka_cluster" "cluster" {
  name             = "test_increase_create_timeout"
  service_provider = "aws"
  region           = "us-east-1"
  availability     = "HIGH"
  environment_id   = "env-abc123"
  deployment = {
    sku = "DEDICATED"
  }
  cku = 10
  timeouts {
    create = "60m"
  }
}
```